### PR TITLE
Fix version numbering in bridgeipelago.py

### DIFF
--- a/bridgeipelago.py
+++ b/bridgeipelago.py
@@ -144,7 +144,7 @@ if EnableFlavorDeathlink == "true":
 ## ARCHIPELAGO TRACKER CLIENT + CORE FUNCTION
 class TrackerClient:
     tags: set[str] = {'Tracker', 'DeathLink'}
-    version: dict[str, any] = {"major": 0, "minor": 4, "build": 6, "class": "Version"}
+    version: dict[str, any] = {"major": 0, "minor": 6, "build": 2, "class": "Version"}
     items_handling: int = 0b000  # This client does not receive any items
 
     class MessageCommand(Enum):


### PR DESCRIPTION
Version fix so the bot connects to the server as a recent server change enforced all bot connections to require exact version equivalence or some shit bro idk